### PR TITLE
Fixes #3 Error on create first if all categories are deleted

### DIFF
--- a/contact_forms.module
+++ b/contact_forms.module
@@ -234,9 +234,12 @@ function contact_forms_edit_form_submit($form, &$form_state) {
     foreach ($categories as $key => $cat) {
       $cids[] = $cat['cid'];
     }
-    $max_cid = max($cids);
-
-    $cid = $max_cid + 1;
+    if (!empty($cids)) {
+      $max_cid = max($cids);
+      $cid = $max_cid + 1;
+    } else {
+      $cid = 1;
+    }
   }
 
   $config = config('contact_forms.extras');


### PR DESCRIPTION
As described in issue #3 when all categories are deleted, an error is caused when the first category is created.  This checks to see if the array is empty first; if it is not empty it increments the id; if it is empty, it sets the id to be 1